### PR TITLE
Filter-transactions-date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "my-calendar-app",
       "version": "0.0.1",
       "dependencies": {
-        "astro": "^5.8.0"
+        "astro": "^5.8.0",
+        "date-fns": "^4.1.0"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -1921,6 +1922,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^5.8.0"
+    "astro": "^5.8.0",
+    "date-fns": "^4.1.0"
   }
 }

--- a/src/pages/api/calendar.ts
+++ b/src/pages/api/calendar.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from "astro";
-import { startOfDay, endOfDay, addMonths, getUnixTime } from "date-fns";
+import { addMonths } from "date-fns";
 
 const GRIST_API_KEY = import.meta.env.GRIST_API_KEY;
 const GRIST_DOC_ID = import.meta.env.GRIST_DOC_ID;
@@ -37,19 +37,15 @@ async function getTransactions(): Promise<GristRecord[]> {
 
 export const GET: APIRoute = async ({ request }) => {
   const now = new Date();
-  const todayStart = startOfDay(now);
-  const twoMonthsLaterEnd = endOfDay(addMonths(now, 2));
-
-  // Formatea las fechas para la API de Grist
-  const startDateUnix = getUnixTime(todayStart);
-  const endDateUnix = getUnixTime(twoMonthsLaterEnd);
+  const todayStart = new Date(now.toISOString().split("T")[0]);
+  const twoMonthsLaterEnd = addMonths(todayStart, 2);
 
   const transactions = await getTransactions();
 
   const filteredTransactions = transactions.filter((item: GristRecord) => {
-    const itemDateTimestamp = item.fields.date;
+    const itemDateTimestamp = new Date(item.fields.date * 1000);
     return (
-      itemDateTimestamp >= startDateUnix && itemDateTimestamp <= endDateUnix
+      itemDateTimestamp >= todayStart && itemDateTimestamp <= twoMonthsLaterEnd
     );
   });
 

--- a/src/pages/api/calendar.ts
+++ b/src/pages/api/calendar.ts
@@ -1,11 +1,21 @@
 import type { APIRoute } from "astro";
+import { startOfDay, endOfDay, addMonths, getUnixTime } from "date-fns";
 
 const GRIST_API_KEY = import.meta.env.GRIST_API_KEY;
 const GRIST_DOC_ID = import.meta.env.GRIST_DOC_ID;
 const GRIST_BASE_URL = import.meta.env.GRIST_BASE_URL;
 const GRIST_TABLE_ID = import.meta.env.GRIST_TABLE_ID;
 
-async function getTransactions() {
+interface GristRecord {
+  id: number;
+  fields: {
+    date: number;
+    amount: number;
+    description: string;
+  };
+}
+
+async function getTransactions(): Promise<GristRecord[]> {
   try {
     const response = await fetch(
       `${GRIST_BASE_URL}/docs/${GRIST_DOC_ID}/tables/${GRIST_TABLE_ID}/records?sort=date`,
@@ -26,8 +36,24 @@ async function getTransactions() {
 }
 
 export const GET: APIRoute = async ({ request }) => {
+  const now = new Date();
+  const todayStart = startOfDay(now);
+  const twoMonthsLaterEnd = endOfDay(addMonths(now, 2));
+
+  // Formatea las fechas para la API de Grist
+  const startDateUnix = getUnixTime(todayStart);
+  const endDateUnix = getUnixTime(twoMonthsLaterEnd);
+
   const transactions = await getTransactions();
-  return new Response(JSON.stringify(transactions), {
+
+  const filteredTransactions = transactions.filter((item: GristRecord) => {
+    const itemDateTimestamp = item.fields.date;
+    return (
+      itemDateTimestamp >= startDateUnix && itemDateTimestamp <= endDateUnix
+    );
+  });
+
+  return new Response(JSON.stringify(filteredTransactions), {
     headers: {
       "Content-Type": "application/json",
     },


### PR DESCRIPTION
- The API now fetches all transactions and filters them for a two-month period from today.
- Utilizes the `date-fns` library for date handling and filtering. `npm i date-fns`
- Returns the filtered transactions in JSON format.

[recording (8).webm](https://github.com/user-attachments/assets/0ea1aae2-c135-4024-a437-1a8be34c595b)
